### PR TITLE
Relax uvicorn version constraint to >=0.32.0 for compatibility on linux-aarch64 platform

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,6 @@ dependencies:
   - requests==2.32.3
   - fastapi=0.112.0
   - typing_extensions=4.11.0
-  - uvicorn=0.32.0
+  - uvicorn>=0.32.0
   - gunicorn=22.0.0
   - pip=23.2.1

--- a/ml/model.py
+++ b/ml/model.py
@@ -19,7 +19,7 @@ def train_model(X_train, y_train):
     model
         Trained machine learning model.
     """
-   # TODO: implement the function
+    # TODO: implement the function
     pass
 
 
@@ -123,6 +123,6 @@ def performance_on_categorical_slice(
         # for input data, use data in column given as "column_name", with the slice_value 
         # use training = False
     )
-    preds = # your code here to get prediction on X_slice using the inference function
+    preds = None # your code here to get prediction on X_slice using the inference function
     precision, recall, fbeta = compute_model_metrics(y_slice, preds)
     return precision, recall, fbeta


### PR DESCRIPTION
This PR addresses an issue encountered when setting up the environment on the linux-aarch64 platform, where the specified version of uvicorn (0.32.0) was not available in the current conda channels. The environment.yml file has been updated to allow for any uvicorn version equal to or above 0.32.0, which should increase compatibility across different architectures.